### PR TITLE
EPIB2B-905 - As a developer, in commerce SDK  project  Authentication…

### DIFF
--- a/CommerceApiSDK/Services/AuthenticationService.cs
+++ b/CommerceApiSDK/Services/AuthenticationService.cs
@@ -76,12 +76,12 @@ namespace CommerceApiSDK.Services
                 return (false, sessionCreateResult?.Error ?? ErrorResponse.Empty());
             }
 
-            Session sessionPatchResult = await this.sessionService.PatchSession(createdSession);
+            ServiceResponse<Session> sessionPatchResult = await this.sessionService.PatchSession(createdSession);
 
             if (sessionPatchResult == null)
             {
                 this.clientService.SetBasicAuthorizationHeader();
-                return (false, ErrorResponse.Empty());
+                return (false, sessionPatchResult?.Error ?? ErrorResponse.Empty());
             }
 
             if (subscriptionToken == null)

--- a/CommerceApiSDK/Services/Interfaces/ISessionService.cs
+++ b/CommerceApiSDK/Services/Interfaces/ISessionService.cs
@@ -16,7 +16,7 @@ namespace CommerceApiSDK.Services.Interfaces
 
         Task<ServiceResponse<Session>> PostSession(Session session);
 
-        Task<Session> PatchSession(Session session);
+        Task<ServiceResponse<Session>> PatchSession(Session session);
 
         Task<Session> GetCurrentSession();
 

--- a/CommerceApiSDK/Services/SessionService.cs
+++ b/CommerceApiSDK/Services/SessionService.cs
@@ -74,24 +74,24 @@ namespace CommerceApiSDK.Services
         /// <param name="session">Session to be updated</param>
         /// <returns>Session result from the server</returns>
         /// <exception cref="Exception">Error when request fails</exception>
-        public async Task<Session> PatchSession(Session session)
+        public async Task<ServiceResponse<Session>> PatchSession(Session session)
         {
             try
             {
                 StringContent stringContent = await Task.Run(() => SerializeModel(session));
-                Session result = await PatchAsyncNoCache<Session>(
+                ServiceResponse<Session> result = await PatchAsyncNoCacheWithErrorMessage<Session>(
                     CommerceAPIConstants.CurrentSessionUrl,
                     stringContent
                 );
 
-                if (result != null)
+                if (result?.Model != null)
                 {
                     // If result != null then patch worked, but we have to call GetCurrentSession to get the most up
                     // to date version of the session
-                    Session currentSession = await GetCurrentSession();
+                    result.Model = await GetCurrentSession(); ;
                 }
 
-                return currentSession;
+                return result;
             }
             catch (Exception exception)
             {


### PR DESCRIPTION
 As a developer, in commerce SDK  project  Authentication/Sessions related post/patch calls have to use base service PostAsyncNoCacheWithErrorMessage/PatchAsyncNoCacheWithErrorMessage to capture error